### PR TITLE
refactor: use `netlink` to refactor bridge creation, iproute2 is not …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ COPY . /src
 WORKDIR /src
 RUN CGO_ENABLED=0 go build -o containervm github.com/cox96de/containervm/cmd/containervm
 FROM debian
-RUN apt update && apt install -y qemu-system iproute2
+RUN apt update && apt install -y qemu-system
 COPY --from=builder /src/containervm /opt
 ENTRYPOINT ["/opt/containervm"]

--- a/cmd/containervm/main.go
+++ b/cmd/containervm/main.go
@@ -58,9 +58,9 @@ func configureNetwork() (bridgeName string, bridgeMacAddr net.HardwareAddr, mtu 
 	lanName := fmt.Sprintf("macvlan%s", randomString(3))
 	tapDevicePath := "/dev/" + tapName
 	err = network.CreateBridge(&network.CreateBridgeOption{
-		NicName:       nic.Name,
-		NicMac:        nic.HardwareAddr,
-		NewNicMac:     util.GetRandomMAC(),
+		NICName:       nic.Name,
+		NICMac:        nic.HardwareAddr,
+		NewNICMac:     util.GetRandomMAC(),
 		TapName:       tapName,
 		TapDevicePath: tapDevicePath,
 		LanName:       lanName,

--- a/util/command_test.go
+++ b/util/command_test.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		_, err := Run("ls", "-alh")
+		assert.NilError(t, err)
+	})
+	t.Run("exit_1", func(t *testing.T) {
+		_, err := Run("bash", "-c", "exit 1")
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+}


### PR DESCRIPTION
…required